### PR TITLE
Changed react-native init command to include the specific RN version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This branch contains all the step executed to:
 
 ### <a name="setup" />[[Setup] Run npx react-native init AwesomeApp --version 0.67.4](https://github.com/react-native-community/RNNewArchitectureApp/commit/2a0578c052b034d3ac230188e53c24c9a4126e00)
 
-1. `npx react-native init AwesomeApp --version 0.67.4`
+1. `npx react-native@0.67.4 init AwesomeApp --version 0.67.4`
 1. `cd AwesomeApp`
 1. `npx react-native start (in another terminal)`
 1. `npx react-native run-ios`


### PR DESCRIPTION
The current command causes ruby errors when run as-is, but according to [this example](https://reactnative.dev/docs/environment-setup?os=macos&platform=ios&guide=native#optional-using-a-specific-version-or-template), the call should be  `npx react-native@X.XX.X init AwesomeApp --version X.XX.X`